### PR TITLE
Made $class parameter optional in `QueueFailed::clear()`

### DIFF
--- a/src/QueueFailed.php
+++ b/src/QueueFailed.php
@@ -133,11 +133,11 @@ class QueueFailed extends Component implements BootstrapInterface
     /**
      * Removes all jobs.
      *
-     * @param $class
+     * @param string|null $class
      * @return int
      * @throws \yii\db\Exception
      */
-    public function clear($class)
+    public function clear($class = null)
     {
         $cond = [];
         if ($class) {


### PR DESCRIPTION
The `$class` parameter can already be empty: https://github.com/silverslice/yii2-queue-failed/blob/main/src/QueueFailed.php#L143.
This PR makes it optional.